### PR TITLE
extract transaction logic

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,18 +1,14 @@
 use std::io::{Write, BufRead};
-use std::time::Duration;
-use std::thread;
 
-use queue_table::{QueueName,QueueTable};
-
-use commands::{Command,UncommittedCommand};
-
-const BLOCKING_POP_POLLING_FREQ:u64 = 100;
+use queue_table::{QueueTable};
+use commands::{Command};
+use transaction::{Transaction,TransactionResult};
 
 pub struct Connection<'a> {
     queue_table: &'a QueueTable,
     reader: &'a mut BufRead,
     writer: &'a mut Write,
-    uncommitted_cmds: Vec<UncommittedCommand>
+    transaction: Transaction,
 }
 
 impl <'a>Connection<'a> {
@@ -21,48 +17,46 @@ impl <'a>Connection<'a> {
             queue_table: &queue_table,
             reader: reader,
             writer: writer,
-            uncommitted_cmds: Vec::new()
+            transaction: Transaction::new(),
         }
     }
 
     pub fn listen(&mut self) {
         loop {
-            let quit = self.process_message();
+            let result = self.process_message();
             self.flush();
-            if quit {
-                self.rollback();
+            if result.is_quit() {
+                self.transaction.rollback(&self.queue_table);
                 break;
             }
         }
     }
 
-    pub fn process_message(&mut self) -> bool {
+    pub fn process_message(&mut self) -> TransactionResult {
         match self.read_message() {
             Ok(result) => {
                 let cmd = Command::parse(result);
                 match cmd {
                     Ok(cmd) => {
-                        if self.is_in_transaction() {
-                            self.exec_cmd_in_transaction(cmd)
-                        } else {
-                            self.exec_cmd(cmd)
-                        }
+                        self.handle_command(cmd)
                     }
                     Err(message) => {
-                        self.write(message.as_bytes());
-                        self.write(b"\r\n");
-                        false
+                        self.write(format!("{}\r\n", message).as_bytes());
+                        TransactionResult::Continue
                     }
                 }
             }
             Err(_) => {
-                true
+                TransactionResult::Quit
             }
         }
     }
 
-    fn is_in_transaction(&self) -> bool {
-        self.uncommitted_cmds.len() > 0
+    pub fn handle_command(&mut self, cmd: Command) -> TransactionResult {
+        let transaction_result = self.transaction.exec(cmd, &self.queue_table);
+        let command_result = transaction_result.command_result();
+        transaction_result.write(self.writer);
+        command_result
     }
 
     fn write(&mut self, buf: &[u8]) {
@@ -88,133 +82,4 @@ impl <'a>Connection<'a> {
 
         return Ok(buffer);
     }
-
-    fn exec_pop(&mut self, queue_name: QueueName) -> Result<(String),()> {
-        match self.queue_table.get_queue(&queue_name) {
-            Some(queue)  => {
-                match queue.pop_front() {
-                    Some(data) => {
-                        self.write(format!("{}\r\n", data).as_bytes());
-                        Ok(data)
-                    }
-                    None => {
-                        self.write(b"NO DATA\r\n");
-                        Err(())
-                    }
-                }
-            }
-            None => {
-                self.write(b"NO SUCH QUEUE\r\n");
-                Err(())
-            }
-        }
-    }
-
-    fn exec_blocking_pop(&mut self, queue_name: QueueName) -> String {
-        let queue = self.queue_table.get_or_create_queue(queue_name);
-        loop {
-            match queue.pop_front() {
-                Some(data) => {
-                    return data;
-                }
-                None => {
-                }
-            }
-            thread::sleep(Duration::from_millis(BLOCKING_POP_POLLING_FREQ));
-        }
-    }
-
-    fn exec_cmd(&mut self, cmd: Command) -> bool {
-        match cmd {
-            Command::Push(value, queue_name) => {
-                exec_push(value, &self.queue_table, queue_name);
-                self.write(b"SUCCESS\r\n");
-            }
-            Command::Pop(queue_name) => {
-                let _ = self.exec_pop(queue_name);
-            }
-            Command::BlockingPop(queue_name) => {
-                let data = self.exec_blocking_pop(queue_name.clone());
-                self.write(format!("{}\r\n", data).as_bytes());
-            }
-            Command::Quit => {
-                self.write(b"Bye bye");
-                return true;
-            }
-            Command::Begin => {
-                self.uncommitted_cmds.push(UncommittedCommand::Begin);
-            }
-            Command::Abort => {
-                self.write(b"Not in transaction\r\n");
-            }
-            Command::Commit => {
-                self.write(b"Not in transaction\r\n");
-            }
-        };
-        false
-    }
-
-    fn exec_cmd_in_transaction(&mut self, cmd: Command) -> bool {
-        match cmd {
-            Command::Push(value, queue_name) => {
-                self.uncommitted_cmds.push(UncommittedCommand::Push(value, queue_name));
-            }
-            Command::Pop(queue_name) => {
-                let data = self.exec_pop(queue_name.clone());
-                if data.is_ok() {
-                    self.uncommitted_cmds.push(UncommittedCommand::Pop(data.unwrap(), queue_name));
-                }
-            }
-            Command::BlockingPop(queue_name) => {
-                let data = self.exec_blocking_pop(queue_name.clone());
-                self.write(format!("{}\r\n", data).as_bytes());
-                self.uncommitted_cmds.push(UncommittedCommand::Pop(data, queue_name));
-            }
-            Command::Quit => {
-                self.write(b"Bye bye");
-                return true;
-            }
-            Command::Begin => {
-                self.write(b"Already in transaction\r\n");
-            }
-            Command::Abort => {
-                self.rollback();
-            }
-            Command::Commit => {
-                self.commit();
-            }
-        };
-        false
-    }
-
-    fn rollback(&mut self) {
-        for cmd in self.uncommitted_cmds.drain(..) {
-            match cmd {
-                UncommittedCommand::Pop(value, queue_name) => {
-                    exec_push(value, &self.queue_table, queue_name);
-                },
-                _ => {
-                }
-            }
-        }
-    }
-
-    fn commit(&mut self) {
-        for cmd in self.uncommitted_cmds.drain(..) {
-            match cmd {
-                UncommittedCommand::Push(value, queue_name) => {
-                    exec_push(value, &self.queue_table, queue_name);
-                }
-                _ => {
-                }
-            }
-        }
-    }
-}
-
-// exec_push can't be moved onto Connection
-// commit and rollback borrow self as mutable once already
-fn exec_push(value: String, queue_table: &QueueTable, queue_name: QueueName) {
-    let queue = queue_table.get_or_create_queue(queue_name);
-    queue.push_back(value.to_string());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ pub mod connection;
 pub mod commands;
 pub mod parse_commands;
 pub mod queue_table;
+pub mod transaction;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,0 +1,206 @@
+use std::io::{Write};
+use std::thread;
+use std::time::Duration;
+
+use queue_table::{QueueName,QueueTable};
+use commands::{Command,UncommittedCommand};
+
+pub enum CommandResult  {
+    Success,
+    Data(String),
+    Error(String),
+    Disconnect,
+}
+
+impl CommandResult {
+    pub fn write(self, writer: &mut Write) {
+        match self {
+            CommandResult::Success => { },
+            CommandResult::Data(message) | CommandResult::Error(message) => {
+                let _ = writer.write(format!("{}\r\n", message).as_bytes());
+            },
+            CommandResult::Disconnect => {
+                let _ = writer.write(b"Bye Bye\r\n");
+            }
+        }
+    }
+
+    pub fn command_result(&self) -> TransactionResult {
+        match *self {
+            CommandResult::Disconnect => {
+                TransactionResult::Quit
+            }
+            _ => {
+                TransactionResult::Continue
+            },
+        }
+    }
+}
+
+pub enum TransactionResult {
+    Continue,
+    Quit,
+}
+
+impl TransactionResult {
+    pub fn is_quit(&self) -> bool {
+        match *self {
+            TransactionResult::Continue => {
+                false
+            },
+            TransactionResult::Quit => {
+                true
+            }
+        }
+    }
+}
+
+const BLOCKING_POP_POLLING_FREQ:u64 = 100;
+
+pub struct Transaction {
+    uncommitted_cmds: Vec<UncommittedCommand>
+}
+
+impl Transaction {
+    pub fn new() -> Transaction {
+        Transaction{ uncommitted_cmds: Vec::new() }
+    }
+
+    pub fn exec(&mut self, cmd: Command, queue_table: &QueueTable) -> CommandResult {
+        if self.uncommitted_cmds.len() > 0 {
+            self.stage_cmd(cmd, queue_table)
+        } else {
+            self.exec_cmd(cmd, queue_table)
+        }
+    }
+
+    fn exec_cmd(&mut self, cmd: Command, queue_table: &QueueTable) -> CommandResult {
+        match cmd {
+            Command::Push(value, queue_name) => {
+                exec_push(value, queue_table, queue_name);
+                CommandResult::Data("SUCCESS".to_string())
+            }
+            Command::Pop(queue_name) => {
+                exec_pop(queue_table, queue_name)
+            }
+            Command::BlockingPop(queue_name) => {
+                let data = exec_blocking_pop(queue_table, queue_name);
+                CommandResult::Data( data)
+            }
+            Command::Quit => {
+                CommandResult::Disconnect
+            }
+            Command::Begin => {
+                self.uncommitted_cmds.push(UncommittedCommand::Begin);
+                CommandResult::Success
+            }
+            Command::Abort => {
+                CommandResult::Error("Not in transaction\r\n".to_string())
+            }
+            Command::Commit => {
+                CommandResult::Error("Not in transaction\r\n".to_string())
+            }
+        }
+    }
+
+    fn stage_cmd(&mut self, cmd: Command, queue_table: &QueueTable) -> CommandResult {
+        match cmd {
+            Command::Push(value, queue_name) => {
+                self.uncommitted_cmds.push(UncommittedCommand::Push(value, queue_name));
+                CommandResult::Success
+            }
+            Command::Pop(queue_name) => {
+                let result = exec_pop(queue_table, queue_name.clone());
+                match result {
+                    CommandResult::Data(data) => {
+                        self.uncommitted_cmds.push(UncommittedCommand::Pop(data.clone(), queue_name));
+                        CommandResult::Data(data)
+                    }
+                    result => {
+                        result
+                    }
+                }
+            }
+            Command::BlockingPop(queue_name) => {
+                let data = exec_blocking_pop(queue_table, queue_name.clone());
+                self.uncommitted_cmds.push(UncommittedCommand::Pop(data.clone(), queue_name));
+                CommandResult::Data(data)
+            }
+            Command::Quit => {
+                CommandResult::Disconnect
+            }
+            Command::Begin => {
+                CommandResult::Error("Already in transaction\r\n".to_string())
+            }
+            Command::Abort => {
+                self.rollback(queue_table);
+                CommandResult::Success
+            }
+            Command::Commit => {
+                self.commit(queue_table);
+                CommandResult::Success
+            }
+        }
+    }
+
+    pub fn rollback(&mut self, queue_table: &QueueTable) {
+        for cmd in self.uncommitted_cmds.drain(..) {
+            match cmd {
+                UncommittedCommand::Pop(value, queue_name) => {
+                    exec_push(value, queue_table, queue_name);
+                },
+                _ => {
+                }
+            }
+        }
+    }
+
+    fn commit(&mut self, queue_table: &QueueTable) {
+        for cmd in self.uncommitted_cmds.drain(..) {
+            match cmd {
+                UncommittedCommand::Push(value, queue_name) => {
+                    exec_push(value, queue_table, queue_name);
+                }
+                _ => {
+                }
+            }
+        }
+    }
+}
+
+fn exec_push(value: String, queue_table: &QueueTable, queue_name: QueueName) {
+    let queue = queue_table.get_or_create_queue(queue_name);
+    queue.push_back(value.to_string());
+}
+
+fn exec_pop(queue_table: &QueueTable, queue_name: QueueName) -> CommandResult {
+    match queue_table.get_queue(&queue_name) {
+        Some(queue)  => {
+            match queue.pop_front() {
+                Some(data) => {
+                    CommandResult::Data(data)
+                }
+                None => {
+                    CommandResult::Error("NO DATA\r\n".to_string())
+                }
+            }
+        }
+        None => {
+            CommandResult::Error("NO SUCH QUEUE\r\n".to_string())
+        }
+    }
+}
+
+fn exec_blocking_pop(queue_table: &QueueTable, queue_name: QueueName) -> String {
+    let queue = queue_table.get_or_create_queue(queue_name);
+    loop {
+        match queue.pop_front() {
+            Some(data) => {
+                return data;
+            }
+            None => {
+            }
+        }
+        thread::sleep(Duration::from_millis(BLOCKING_POP_POLLING_FREQ));
+    }
+}


### PR DESCRIPTION
It was bugging me that `connection.rs` held logic around executing commands and the tcp message loop.

I tried to replace the `Command` enum with a trait and structs but got bogged down. Extracting a `Transaction` struct seemed like a better bet.

There's work left to properly define how transactions should behave.
